### PR TITLE
Remove console.log from http-connection

### DIFF
--- a/packages/fints/src/http-connection.ts
+++ b/packages/fints/src/http-connection.ts
@@ -30,7 +30,6 @@ export class HttpConnection extends ConnectionConfig implements Connection {
 
     public async send(request: Request): Promise<Response> {
         const {url} = this;
-        console.log(`Sending Request: ${request}`);
         verbose(`Sending Request: ${request}`);
         if (this.debug) {
             verbose(`Parsed Request:\n${request.debugString}`);
@@ -44,7 +43,6 @@ export class HttpConnection extends ConnectionConfig implements Connection {
         }
 
         const responseString = decodeBase64(await httpRequest.text());
-        console.log(`Received Response: ${responseString}`);
         verbose(`Received Response: ${responseString}`);
         const response = new Response(responseString);
         if (this.debug) {


### PR DESCRIPTION
This currently spams the stdout with debug messages. Since they are already logged via winston, there is no need for this in production.